### PR TITLE
Doc tweaks, bug fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "nxus-renderer": "^3.0.0-0",
     "nxus-templater": "^3.0.0-0",
     "nxus-router": "^3.0.0-0",
-    "nxus-storage": "^3.0.0-0"
+    "nxus-storage": "^3.0.0-1"
   },
   "devDependencies": {
     "mocha": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-base-ui",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "description": "Basic UI pages for Nxus apps, like 404 and 500 pages",
   "main": "lib",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,11 @@
  * So using the examples above:
  *
  * ```
- * app.get('templater').replace().templateFunction('view-user-list', (opts) => {
+ * app.get('templater').templateFunction('view-user-list', (opts) => {
  *   return app.get('renderer').render("<% users.forEach(function(user){ .... }) %>", opts)
  * })
  * 
- * app.get('templater').replace().templateFunction('view-user-detail', (opts) => {
+ * app.get('templater').templateFunction('view-user-detail', (opts) => {
  *   return app.get('renderer').render("<%= user.email %>", opts)
  * })
  * ```

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,11 @@
  * So using the examples above:
  *
  * ```
- * app.get('templater').template('view-user-list', (opts) => {
+ * app.get('templater').replace().templateFunction('view-user-list', (opts) => {
  *   return app.get('renderer').render("<% users.forEach(function(user){ .... }) %>", opts)
  * })
  * 
- * app.get('templater').template('view-user-detail', (opts) => {
+ * app.get('templater').replace().templateFunction('view-user-detail', (opts) => {
  *   return app.get('renderer').render("<%= user.email %>", opts)
  * })
  * ```
@@ -84,6 +84,7 @@
 import ViewBaseClass from './viewBase'
 import _ from 'underscore'
 import path from 'path'
+import fs from 'fs'
 
 export var ViewBase = ViewBaseClass
 

--- a/src/index.js
+++ b/src/index.js
@@ -142,20 +142,17 @@ export default class BaseUI {
       this.app.log.debug('Loading view model', model)
       opts.model = model
       viewModel = new ViewBase(this.app, opts)
-      console.log('viewmodel name', viewModel.model())
       this.models[model] = viewModel
     } else if(_.isString(model) && model.indexOf(path.sep) > -1) {
       if(fs.existsSync(model)) {
         this.app.log.debug('Loading view model file at', model)
         model = require(model);
         viewModel = new model(this.app);
-        console.log('viewmodel name', viewModel.model())
         this.models[viewModel.model()] = viewModel
       } else
         throw new Error('Class path '+model+' is not a valid file')
     } else if(_.isFunction(model)) {
       viewModel = new model(this.app)
-      console.log('viewmodel name', viewModel.model())
       this.models[viewModel.model()] = viewModel
     }
   }

--- a/src/viewBase.js
+++ b/src/viewBase.js
@@ -250,7 +250,8 @@ export default class ViewBase extends HasModels {
   }
 
   _populate(find) {
-    this.modelPopulate().forEach((attr) => { find = find.populate(attr) })
+    let populate = this.modelPopulate()
+    if (populate.length > 0) find = find.populate(populate)
     return find
   }
 

--- a/src/viewBase.js
+++ b/src/viewBase.js
@@ -57,8 +57,8 @@ export default class ViewBase extends HasModels {
   }
   
   /**
-   * The ID field to use to display a single itme
-   * @return {array}
+   * The ID field to use to display a single item
+   * @return {string}
    */
   idField() {
     return this.opts.idField || 'id'
@@ -73,7 +73,7 @@ export default class ViewBase extends HasModels {
   }
 
   /**
-   * Fields in the model to use for the instance title
+   * Field in the model to use for the instance title
    * @return {string}
    */
   titleField() {
@@ -81,7 +81,7 @@ export default class ViewBase extends HasModels {
   }
 
   /**
-   * Fields in the model to use for sorting the list
+   * Field in the model to use for sorting the list
    * @return {string}
    */
   sortField() {
@@ -90,7 +90,7 @@ export default class ViewBase extends HasModels {
 
   /**
    * List sort direction
-   * @return {string}
+   * @return {string} `ASC` for ascending, `DESC` for descending order
    */
   sortDirection() {
     return this.opts.sortDirection || 'ASC'
@@ -129,7 +129,8 @@ export default class ViewBase extends HasModels {
   }
 
   /**
-   * The prefix to use for the templates. Defaults to `view-<model>-`
+   * The prefix to use for the templates. Defaults to `view-<model>-`,
+   * where `<model>` is the model name morphed into dashed format.
    * @return {string}
    */
   templatePrefix() {
@@ -138,7 +139,7 @@ export default class ViewBase extends HasModels {
 
   /**
    * The display name for the model to use in the  UI
-   * @return {string} Defaults to `<model>`
+   * @return {string} Defaults to `<model>`, the model name morphed into title-case format.
    */
   displayName() {
     return this.opts.displayName || morph.toTitle(this.model())
@@ -178,10 +179,9 @@ export default class ViewBase extends HasModels {
   list (req, res, opts = {}) {
     let sort = this.sortField()+" "+this.sortDirection()
     let page = parseInt(req.param('page')) || 1
-    let find = this.models[this.model()].find().where({}).sort(sort).limit(this.itemsPerPage()).skip((page-1)*this.itemsPerPage())
-    if (this.modelPopulate && this.modelPopulate().length > 0) {
-      find = find.populate(...this.modelPopulate())
-    }
+    let find = this.models[this.model()].find().where({}).sort(sort)
+      .limit(this.itemsPerPage()).skip((page-1)*this.itemsPerPage())
+    find = this._populate(find)
     let count = this.models[this.model()].count().where({})
     return count.then((count) => {
       return [count, find]
@@ -210,9 +210,7 @@ export default class ViewBase extends HasModels {
     let query = {}
     query[this.idField()] = req.params[this.idField()]
     let find = this.models[this.model()].findOne().where(query)
-    if (this.modelPopulate && this.modelPopulate().length > 0) {
-      find = find.populate(...this.modelPopulate())
-    }
+    find = this._populate(find)
     return find.then((inst) => {
       if(!inst) return res.status(404).send()
       opts = _.extend({
@@ -249,6 +247,11 @@ export default class ViewBase extends HasModels {
       if(!ret) ret = _(ignoreType).contains(k.type)
       return !ret
     })
+  }
+
+  _populate(find) {
+    this.modelPopulate().forEach((attr) => { find = find.populate(attr) })
+    return find
   }
 
   _sanitizeName(string) {


### PR DESCRIPTION
Need to use replace() to override default list and view templates.

Import of fs was missing from index.js.

Noted that model name is morphed to produce template names, title string.

Waterline populate() method doesn't take an array argument of
attribute names -- must be called repeatedly, once for each attribute.
