### PR TITLE
Fixed problem with paginator next-page control.

### DIFF
--- a/views/paginator.ejs
+++ b/views/paginator.ejs
@@ -2,9 +2,9 @@
 <% var base = '/' %>
 <% } %>
 <% var page = parseInt(req.param('page')) || 1 %>
+<% var totalPages = Math.ceil(total/itemsPerPage) %>
 <% var previousPage = page > 1 ? page-1 : null %>
 <% var nextPage = page < totalPages ? page+1 : null %>
-<% var totalPages = Math.ceil(total/itemsPerPage) %>
 <% var pages = _.range(page < 3 ? 1 : page-2, page > totalPages-3 ? totalPages+1 : (page < 3 ? 6 : page+3)) %>
 <% if(pages.length > 1) { %> 
 <ul class="pagination">


### PR DESCRIPTION
Out-of-order statements caused `totalPages` to be referenced while
still undefined.
